### PR TITLE
Compatibility fixes for unit tests. PHPUnit will save global state with ...

### DIFF
--- a/drivers/pdo_mysql.php
+++ b/drivers/pdo_mysql.php
@@ -191,4 +191,12 @@ class wpdb_driver_pdo_mysql implements wpdb_driver {
 	public function db_version() {
 		return preg_replace( '/[^0-9.].*/', '', $this->dbh->getAttribute( PDO::ATTR_SERVER_VERSION ) );
 	}
+
+	/**
+	 * Don't save any state.  The db wrapper should call connect() again.
+	 * @return array
+	 */
+	public function __sleep() {
+		return array();
+	}
 }


### PR DESCRIPTION
...serialize/unserialize, but PDO connections can't be serialized, so they should be discarded.  The unit test setUp() method will handle the db reconnect for us.
