### PR TITLE
Fix bug that causes dbDelta() to not create tables when the tables do no...

### DIFF
--- a/db.php
+++ b/db.php
@@ -182,11 +182,7 @@ class wpdb_drivers extends wpdb {
 	 */
 	function flush() {
 		$this->dbh->flush();
-		$this->last_result = array();
-		$this->col_info    = null;
-		$this->last_query  = null;
-		$this->rows_affected = $this->num_rows = 0;
-		$this->last_error  = '';
+		parent::flush();
 	}
 
 	/**


### PR DESCRIPTION
...t exist.

For a description of the problem this commit solves, see
https://wordpress.org/support/topic/dbdelta-fails-to-create-new-tables?replies=1#post-4492564
