### PR TITLE
Fix some queries returning wrong number of rows.

### DIFF
--- a/db.php
+++ b/db.php
@@ -297,7 +297,7 @@ class wpdb_drivers extends wpdb {
 			// Return number of rows affected
 			$return_val = $this->rows_affected;
 		} else {
-			$return_val = $this->num_rows = count( $this->last_result );
+			$return_val = $this->num_rows = count( $this->result );
 		}
 
 		$this->last_result = $this->dbh->get_results();


### PR DESCRIPTION
wb-db-driver 1.5, WordPress 3.6, PHP version 5.5.1, PDO driver, MariaDB version 5.5.31.

Some queries (anything other than create, alter, truncate, drop, insert, delete, update, replace) may return the wrong number of rows.  Example:

```
global $wpdb;
$table_name = $wbdp->prefix . 'posts';
if( ! $wpdb->query( "SHOW TABLES LIKE '{$table_name}';" ) ) {
    error_log( "Oh no, the WordPress posts table, ${table_name}, does not exist!" );
} else {
    error_log( "All is well." );
}
```

When run, the above code will claim that the posts table does not exist, even though it does exist.  This is a real-world test case from a plugin that fails to work with wp-db-driver, the Wysija Newsletters plugin, see lines 495-497 of
http://plugins.trac.wordpress.org/browser/wysija-newsletters/trunk/helpers/install.php#495

(Note that additional changes to Wysija Newletters are needed to get it to work with wp-db-driver)

The problem is due to last_result being used on line 300 of wp-db-drivers/db.php before it gets set on line 303; the fix is straightforward.
