### PR TITLE
Switch to using `WP_PLUGIN_DIR` instead of `WP_CONTENT_DIR/plugins`

### DIFF
--- a/wp-content/db.php
+++ b/wp-content/db.php
@@ -7,7 +7,7 @@ if ( isset( $_GET['wp-db-driver-emergency-override'] ) ) {
 if (
 	! isset( $_COOKIE['wp-db-driver-emergency-override'] ) &&
 	! isset( $_REQUEST['wp-db-driver-emergency-override'] ) &&
-	is_file( WP_CONTENT_DIR . '/plugins/wp-db-driver/db.php' ) )
+	is_file( WP_PLUGIN_DIR . '/wp-db-driver/db.php' ) )
 {
-	require( WP_CONTENT_DIR . '/plugins/wp-db-driver/db.php' );
+	require( WP_PLUGIN_DIR . '/wp-db-driver/db.php' );
 }


### PR DESCRIPTION
If you're using a custom location for your plugin directory, this plugin silently fails and causes head scratching. This fixes that.
