### PR TITLE
Handle custom defined WP_PLUGIN_DIR

### DIFF
--- a/wp-content/db.php
+++ b/wp-content/db.php
@@ -4,10 +4,15 @@ if ( isset( $_GET['wp-db-driver-emergency-override'] ) ) {
 	setcookie( 'wp-db-driver-emergency-override', 1, 0, '/', $_SERVER['HTTP_HOST'] );
 }
 
+$db_plugin_file = WP_CONTENT_DIR . '/plugins/wp-db-driver/db.php';
+if ( defined( 'WP_PLUGIN_DIR' ) ) {
+	$db_plugin_file = WP_PLUGIN_DIR . '/wp-db-driver/db.php';
+}
+
 if (
 	! isset( $_COOKIE['wp-db-driver-emergency-override'] ) &&
 	! isset( $_REQUEST['wp-db-driver-emergency-override'] ) &&
-	is_file( WP_PLUGIN_DIR . '/wp-db-driver/db.php' ) )
+	is_file( $db_plugin_file ) )
 {
-	require( WP_PLUGIN_DIR . '/wp-db-driver/db.php' );
+	require( $db_plugin_file );
 }


### PR DESCRIPTION
When a user defines WP_PLUGIN_DIR in wp-config, it will exist when the plugin is loaded.  However, if it's not defined in wp-config, then we have to fall back to WP_CONTENT_DIR/plugins.
