### PR TITLE
Fix crash using PDO and PHP 7

### DIFF
--- a/drivers/pdo_mysql.php
+++ b/drivers/pdo_mysql.php
@@ -274,8 +274,10 @@ class wpdb_driver_pdo_mysql extends wpdb_driver {
 
 		if ( !empty( $this->result ) && $this->result->rowCount() > 0 ) {
 			try {
-				while ( $row = $this->result->fetchObject() ) {
+				$row = $this->result->fetchObject();
+				while ( $row ) {
 					$this->fetched_rows[] = $row;
+					$row = $this->result->fetchObject();
 				}
 			} catch ( Exception $e ) {
 			}


### PR DESCRIPTION
By extracting the $row assignment from the while loop using the PDO driver in PHP7 does not crash anymore.